### PR TITLE
CI: Docker Multi-Platform Image

### DIFF
--- a/.github/workflows/build-and-test-backend.yml
+++ b/.github/workflows/build-and-test-backend.yml
@@ -2,10 +2,11 @@ name: Gradle Build
 
 on:
   push:
+    branches:
+      - feature/**
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -1,4 +1,4 @@
-name: Gradle Build
+name: Feature Branch Continuous Integration
 
 on:
   push:

--- a/.github/workflows/cr-main.yml
+++ b/.github/workflows/cr-main.yml
@@ -1,4 +1,20 @@
-name: Master Branch Continuous Release
+# This workflow is triggered on pushes to the main branch.
+# It builds the agent and creates a multi-arch image for it.
+# The image is then pushed to Docker Hub.
+#
+# The workflow consists of three jobs:
+# 1. build-agent: Builds the agent and uploads the resulting JAR as an artifact.
+# 2. build-image: Builds a Docker image for multiple platforms with the matrix strategy.
+# 3. merge: Merges the images for the different platforms into a manifest list and pushes it to Docker Hub.
+
+# To make the build faster, we use a matrix strategy to build the image for multiple platforms in parallel.
+# The build of the first job is copied over to the image build jobs, so that the application build is only done once.
+# QUEMU is used to emulate the different platforms on the GitHub runner.
+
+# For more information about how to build multi-arch images and advanced settings with Docker Buildx in GitHub actions, see:
+# https://docs.docker.com/build/ci/github-actions/multi-platform/
+
+name: Main Branch Continuous Release
 
 on:
   push:

--- a/.github/workflows/cr-main.yml
+++ b/.github/workflows/cr-main.yml
@@ -10,7 +10,7 @@ env:
   REGISTRY_IMAGE: inspectit/inspectit-gepard-configserver
 
 jobs:
-  build-jar:
+  build-configserver:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
           path: backend/build/libs/backend-0.0.1-SNAPSHOT.jar
   build-image:
     runs-on: ubuntu-latest
-    needs: build-agent
+    needs: build-configserver
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cr-main.yml
+++ b/.github/workflows/cr-main.yml
@@ -3,8 +3,7 @@ name: Master Branch Continuous Release
 on:
   push:
     branches:
-      - master
-      - feature/vhvapm-547
+      - main
 
 env:
   REGISTRY_IMAGE: inspectit/inspectit-gepard-configserver

--- a/.github/workflows/cr-main.yml
+++ b/.github/workflows/cr-main.yml
@@ -7,7 +7,7 @@ on:
       - feature/vhvapm-547
 
 env:
-  REGISTRY_IMAGE: inspectit/inspectit-gepard-agent
+  REGISTRY_IMAGE: inspectit/inspectit-gepard-configserver
 
 jobs:
   build-jar:
@@ -33,5 +33,109 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: agent-artifact
+          name: configserver-artifact
           path: backend/build/libs/backend-0.0.1-SNAPSHOT.jar
+  build-image:
+    runs-on: ubuntu-latest
+    needs: build-agent
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: configserver-artifact
+          path: ./  # Download artifact to the root of the Docker build context
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: "./backend/Dockerfile-CR"
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build-image
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/cr-main.yml
+++ b/.github/workflows/cr-main.yml
@@ -43,7 +43,6 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          - linux/arm/v7
           - linux/arm64
     steps:
       - name: Checkout

--- a/.github/workflows/cr-main.yml
+++ b/.github/workflows/cr-main.yml
@@ -43,7 +43,6 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          - linux/arm/v6
           - linux/arm/v7
           - linux/arm64
     steps:

--- a/.github/workflows/cr-main.yml
+++ b/.github/workflows/cr-main.yml
@@ -1,0 +1,36 @@
+name: Master Branch Continuous Release
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY_IMAGE: inspectit/inspectit-gepard-agent
+
+jobs:
+  build-jar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-service-url: "https://gradle.com/terms-of-service"
+          build-scan-terms-of-service-agree: "yes"
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: agent-artifact
+          path: backend/build/libs/backend-0.0.1-SNAPSHOT.jar

--- a/.github/workflows/cr-main.yml
+++ b/.github/workflows/cr-main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feature/vhvapm-547
 
 env:
   REGISTRY_IMAGE: inspectit/inspectit-gepard-agent

--- a/backend/Dockerfile-CR
+++ b/backend/Dockerfile-CR
@@ -1,0 +1,11 @@
+# ---- Runtime Stage ----
+# We use Temurin as it is the default at VHV
+FROM eclipse-temurin:21-jre-jammy
+
+COPY ./inspectit-gepard-agent.jar ./app.jar
+
+# Expose the port on which the app will run
+EXPOSE 8080
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/backend/Dockerfile-CR
+++ b/backend/Dockerfile-CR
@@ -2,7 +2,7 @@
 # We use Temurin as it is the default at VHV
 FROM eclipse-temurin:21-jre-jammy
 
-COPY ./inspectit-gepard-agent.jar ./app.jar
+COPY ./backend-0.0.1-SNAPSHOT.jar ./app.jar
 
 # Expose the port on which the app will run
 EXPOSE 8080


### PR DESCRIPTION
This PR adds a basic CI-Workflow to release a Multi-Platform Image on the InspectIT Docker Hub, when pushing to main.

This is required, cause we want to deploy a Integration / Demo-Environment on AWS for showcase purposes.