### PR TITLE
feat: use instant instead of localdatetime

### DIFF
--- a/backend/src/main/java/rocks/inspectit/gepard/agentmanager/connection/model/Connection.java
+++ b/backend/src/main/java/rocks/inspectit/gepard/agentmanager/connection/model/Connection.java
@@ -1,6 +1,7 @@
 /* (C) 2024 */
 package rocks.inspectit.gepard.agentmanager.connection.model;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.*;
@@ -21,7 +22,7 @@ public class Connection {
   private UUID id;
 
   /** The registration time * */
-  private LocalDateTime registrationTime;
+  private Instant registrationTime;
 
   /** The agent which is connected. */
   private Agent agent;

--- a/backend/src/main/java/rocks/inspectit/gepard/agentmanager/connection/model/dto/ConnectionDto.java
+++ b/backend/src/main/java/rocks/inspectit/gepard/agentmanager/connection/model/dto/ConnectionDto.java
@@ -2,6 +2,8 @@
 package rocks.inspectit.gepard.agentmanager.connection.model.dto;
 
 import jakarta.validation.constraints.NotNull;
+
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
@@ -10,12 +12,12 @@ import rocks.inspectit.gepard.agentmanager.connection.model.Connection;
 /** Represents a connection response. */
 public record ConnectionDto(
     @NotNull(message = "ID missing.") UUID id,
-    @NotNull(message = "Registration Time missing.") LocalDateTime registrationTime,
+    @NotNull(message = "Registration Time missing.") Instant registrationTime,
     @NotNull(message = "Service Name missing.") String serviceName,
     @NotNull(message = "Gepard Version missing.") String gepardVersion,
     @NotNull(message = "Open-Telemetry Version missing.") String otelVersion,
     @NotNull(message = "Process ID is missing.") Long pid,
-    @NotNull(message = "Start-Time missing.") Long startTime,
+    @NotNull(message = "Start-Time missing.") Instant startTime,
     @NotNull(message = "Java Version missing.") String javaVersion,
     @NotNull(message = "Attributes are missing.") Map<String, String> attributes) {
 
@@ -27,7 +29,7 @@ public record ConnectionDto(
         connection.getAgent().getGepardVersion(),
         connection.getAgent().getOtelVersion(),
         connection.getAgent().getPid(),
-        connection.getAgent().getStartTime().toEpochMilli(),
+        connection.getAgent().getStartTime(),
         connection.getAgent().getJavaVersion(),
         connection.getAgent().getAttributes());
   }

--- a/backend/src/main/java/rocks/inspectit/gepard/agentmanager/connection/model/dto/CreateConnectionRequest.java
+++ b/backend/src/main/java/rocks/inspectit/gepard/agentmanager/connection/model/dto/CreateConnectionRequest.java
@@ -22,7 +22,7 @@ public record CreateConnectionRequest(
   public static Connection toConnection(CreateConnectionRequest createConnectionRequest) {
     return new Connection(
         UUID.randomUUID(),
-        LocalDateTime.now(),
+        Instant.now(),
         new Agent(
             createConnectionRequest.serviceName,
             createConnectionRequest.pid,

--- a/backend/src/test/java/rocks/inspectit/gepard/agentmanager/connection/controller/ConnectionControllerTest.java
+++ b/backend/src/test/java/rocks/inspectit/gepard/agentmanager/connection/controller/ConnectionControllerTest.java
@@ -93,7 +93,7 @@ class ConnectionControllerTest {
     UUID uuid = UUID.randomUUID();
     ConnectionDto connectionDto =
         new ConnectionDto(
-            uuid, LocalDateTime.now(), "service name", "5", "7", 42L, 123456789L, "22", Map.of());
+            uuid, Instant.now(), "service name", "5", "7", 42L, Instant.now(), "22", Map.of());
     when(connectionService.getConnection(uuid)).thenReturn(connectionDto);
 
     mockMvc
@@ -116,12 +116,12 @@ class ConnectionControllerTest {
         List.of(
             new ConnectionDto(
                 UUID.randomUUID(),
-                LocalDateTime.now(),
+                Instant.now(),
                 "service-name",
                 "0.0.1",
                 "1.26.8",
                 67887L,
-                123456789L,
+                Instant.now(),
                 "22",
                 Map.of()));
 
@@ -174,12 +174,12 @@ class ConnectionControllerTest {
         List.of(
             new ConnectionDto(
                 UUID.fromString("123e4567-e89b-12d3-a456-426614174000"),
-                LocalDateTime.parse("2023-04-15T12:34:56"),
+                Instant.parse("2023-04-15T12:34:56Z"),
                 "service-name",
                 "0.0.1",
                 "1.26.8",
                 67887L,
-                123456789L,
+                Instant.now(),
                 "22",
                 Map.of("key", "value-123")));
 

--- a/backend/src/test/java/rocks/inspectit/gepard/agentmanager/connection/service/ConnectionServiceTest.java
+++ b/backend/src/test/java/rocks/inspectit/gepard/agentmanager/connection/service/ConnectionServiceTest.java
@@ -104,7 +104,7 @@ class ConnectionServiceTest {
     ConnectionDto connectionDto = connectionService.getConnection(connection.getId());
 
     assertEquals(connection.getId(), connectionDto.id());
-    assertEquals(createConnectionRequest.startTime(), connectionDto.startTime());
+    assertEquals(Instant.ofEpochMilli(createConnectionRequest.startTime()), connectionDto.startTime());
     assertEquals(createConnectionRequest.javaVersion(), connectionDto.javaVersion());
     assertEquals(createConnectionRequest.otelVersion(), connectionDto.otelVersion());
     assertEquals(createConnectionRequest.gepardVersion(), connectionDto.gepardVersion());
@@ -147,7 +147,7 @@ class ConnectionServiceTest {
   void testQueryShouldFindConnectionByRegistrationTime() {
     // given
     UUID id = UUID.randomUUID();
-    LocalDateTime registrationTime = LocalDateTime.now();
+    Instant registrationTime = Instant.now();
     Connection connection = createTestConnection(id, registrationTime);
     connectionCache.put(id, connection);
 
@@ -232,7 +232,7 @@ class ConnectionServiceTest {
   void testQueryShouldFindConnectionWithMultipleCriteria() {
     // given
     UUID id = UUID.randomUUID();
-    LocalDateTime registrationTime = LocalDateTime.now();
+    Instant registrationTime = Instant.now();
     Map<String, String> attributes = Map.of("custom", "attribute");
     Connection connection = createTestConnectionWithAttributes(id, registrationTime, attributes);
     connectionCache.put(id, connection);
@@ -300,15 +300,15 @@ class ConnectionServiceTest {
   @Test
   void testQueryShouldFindConnectionsByRegexRegistrationTime() {
     // given
-    LocalDateTime registrationTime1 = LocalDateTime.parse("2023-04-15T12:34:56");
-    LocalDateTime registrationTime2 = LocalDateTime.parse("2023-04-16T12:34:56");
+    Instant registrationTime1 = Instant.parse("2023-04-15T12:34:56Z");
+    Instant registrationTime2 = Instant.parse("2023-04-16T12:34:56Z");
     Connection connection1 = createTestConnection(UUID.randomUUID(), registrationTime1);
     Connection connection2 = createTestConnection(UUID.randomUUID(), registrationTime2);
     connectionCache.put(connection1.getId(), connection1);
     connectionCache.put(connection2.getId(), connection2);
 
     QueryConnectionRequest query =
-        new QueryConnectionRequest(null, "regex:^2023-04-[0-9]+T[0-9:]+$", null);
+        new QueryConnectionRequest(null, "regex:^2023-04-[0-9]+T[0-9:]+Z$", null);
 
     // when
     List<ConnectionDto> result = connectionService.queryConnections(query);
@@ -375,7 +375,7 @@ class ConnectionServiceTest {
     assertThat(result).hasSize(1);
 
     // Assert that start time of result is within 1 second of nearStartTime
-    Instant resultStartTime = Instant.ofEpochMilli(result.get(0).startTime());
+    Instant resultStartTime = result.get(0).startTime();
     assertThat(resultStartTime)
         .isBetween(nearStartTime.minusSeconds(1), nearStartTime.plusSeconds(1));
   }
@@ -409,19 +409,19 @@ class ConnectionServiceTest {
   }
 
   private Connection createTestConnection(UUID id) {
-    return createTestConnection(id, LocalDateTime.now(), "testService");
+    return createTestConnection(id, Instant.now(), "testService");
   }
 
-  private Connection createTestConnection(UUID id, LocalDateTime registrationTime) {
+  private Connection createTestConnection(UUID id, Instant registrationTime) {
     return createTestConnection(id, registrationTime, "testService");
   }
 
   private Connection createTestConnection(UUID id, String serviceName) {
-    return createTestConnection(id, LocalDateTime.now(), serviceName);
+    return createTestConnection(id, Instant.now(), serviceName);
   }
 
   private Connection createTestConnection(
-      UUID id, LocalDateTime registrationTime, String serviceName) {
+      UUID id, Instant registrationTime, String serviceName) {
     return new Connection(
         id,
         registrationTime,
@@ -429,11 +429,11 @@ class ConnectionServiceTest {
   }
 
   private Connection createTestConnectionWithAttributes(UUID id, Map<String, String> attributes) {
-    return createTestConnectionWithAttributes(id, LocalDateTime.now(), attributes);
+    return createTestConnectionWithAttributes(id, Instant.now(), attributes);
   }
 
   private Connection createTestConnectionWithAttributes(
-      UUID id, LocalDateTime registrationTime, Map<String, String> attributes) {
+      UUID id, Instant registrationTime, Map<String, String> attributes) {
     return new Connection(
         id,
         registrationTime,


### PR DESCRIPTION
It was pretty painful to handle the date/time-stuff in the frontend... Timezones etc. 
Thus, we needed to adjust the backend a little.

Instants return a ISO 8601 UTC-Timestamp, which is unambiguously, pretty, parsable and readable. 
Fit´s the needs way better than a LocalDateTime, cause LocalDateTime is ambiguous.

Frontend will be adjusted in the other PR, thus blocks #10.